### PR TITLE
When LOCAL_NIDS_RULE_TUNING was set to "yes" on a sensor, the update …

### DIFF
--- a/usr/bin/rule-update
+++ b/usr/bin/rule-update
@@ -261,7 +261,7 @@ else
 
 		# Process rules local to sensor without starting a separate download.
 		echo "Running PulledPork."		
-		su - $PULLEDPORK_USER -c "/usr/bin/pulledpork.pl -P -n "$PP_OPTIONS" -c /etc/nsm/pulledpork/pulledpork.conf" |
+		su - $PULLEDPORK_USER -c "/usr/bin/pulledpork.pl -P -n $PP_OPTIONS -c /etc/nsm/pulledpork/pulledpork.conf" |
 			grep -v "normalizations disabled because not inline" |grep -v "^$"
 	else
 		#### Default ####


### PR DESCRIPTION
When LOCAL_NIDS_RULE_TUNING was set to "yes" on a sensor, the update process would complain that "-T" was not a valid option for su, causing rules to never get updated properly. Of course, this is supposed to be an option for PulledPork.  

Looks like there is similar code to call PP in two places (for the sensor, for the server).  It was fixed on the server call, but not where it was called on the sensor.  This fixes that.
