### PR TITLE
always log rule-update output to pulledpork.log

### DIFF
--- a/etc/cron.d/rule-update
+++ b/etc/cron.d/rule-update
@@ -5,4 +5,4 @@
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-01 7    * * *   root    date >> /var/log/nsm/pulledpork.log ; /usr/bin/rule-update cron >> /var/log/nsm/pulledpork.log 2>&1
+01 7    * * *   root    /usr/bin/rule-update

--- a/usr/bin/rule-update
+++ b/usr/bin/rule-update
@@ -51,6 +51,9 @@ PULLEDPORK_GROUP=sguil
 # The values above can be overridden in securityonion.conf
 source /etc/nsm/securityonion.conf
 
+# Log file path
+LOG="/var/log/nsm/pulledpork.log"
+
 #########################################
 # OSSEC HIDS Variables and Backups
 #########################################
@@ -59,6 +62,11 @@ source /etc/nsm/securityonion.conf
 HIDS=/var/ossec/rules
 HIDS_RULES=$HIDS/local_rules.xml
 		
+function update(){
+
+# Get current date
+date
+
 # Create backup directory if it doesn't already exist
 HIDS_RULES_BACK=$HIDS/backup
 mkdir -p $HIDS_RULES_BACK
@@ -303,3 +311,5 @@ if grep -i 'IDS_ENGINE_ENABLED="yes"' /etc/nsm/*/sensor.conf >/dev/null 2>&1; th
 		/usr/sbin/nsm_sensor_ps-restart --only-snort-alert
 	fi
 fi
+}
+update 2>&1 | tee -a $LOG

--- a/usr/bin/rule-update
+++ b/usr/bin/rule-update
@@ -23,6 +23,11 @@ if [[ $(/usr/bin/id -u) -ne 0 ]]; then
     exit
 fi
 
+# Log file path
+LOG="/var/log/nsm/pulledpork.log"
+
+function update(){
+
 #########################################
 # Variables
 #########################################
@@ -51,8 +56,8 @@ PULLEDPORK_GROUP=sguil
 # The values above can be overridden in securityonion.conf
 source /etc/nsm/securityonion.conf
 
-# Log file path
-LOG="/var/log/nsm/pulledpork.log"
+# Current date
+date
 
 #########################################
 # OSSEC HIDS Variables and Backups
@@ -62,11 +67,6 @@ LOG="/var/log/nsm/pulledpork.log"
 HIDS=/var/ossec/rules
 HIDS_RULES=$HIDS/local_rules.xml
 		
-function update(){
-
-# Get current date
-date
-
 # Create backup directory if it doesn't already exist
 HIDS_RULES_BACK=$HIDS/backup
 mkdir -p $HIDS_RULES_BACK
@@ -131,7 +131,7 @@ if [ ! -f $SSH_CONF ]; then
 	# This box is a master server.
 
 	# If running from cron, pause for a random number of minutes (between 10 and 50).
-	if [ $# -eq 1 ] && [ $1 == "cron" ]; then
+	if [ "dumb" == "$TERM" ]; then
 		RMIN=$(($(dd if=/dev/urandom count=1 2> /dev/null | cksum | cut -d' ' -f1) % 40));
 		let RMIN=RMIN+10
 		echo "Sleeping for $RMIN minutes to avoid overwhelming rule sites."
@@ -191,7 +191,7 @@ else
 	source $SSH_CONF		
 
 	# If running from cron, pause for 60 minutes.
-	if [ $# -eq 1 ] && [ $1 == "cron" ]; then
+	if [ "dumb" == "$TERM" ]; then
 		echo "Sleeping for 60 minutes to allow master time to download new rules."
 		sleep 60m 
 	fi


### PR DESCRIPTION
Includes modifications to /etc/cron.d/rule-update and /usr/bin/rule-update so that rule-update output is always logged to /var/log/nsm/pulledpork.log

Please let me know if anything should be changed.

I noticed rule-update check to see if the script was run from cron (/usr/bin/rule-update cron), so I wasn't sure if the cron entry would still need to be formatted as before for the randomized rule updates to still occur (if [ $# -eq 1 ] && [ $1 == "cron" ])

Ref:https://github.com/Security-Onion-Solutions/security-onion/issues/985

Thanks,
Wes
