### PR TITLE
Restore stdout redirect in crontab

### DIFF
--- a/etc/cron.d/rule-update
+++ b/etc/cron.d/rule-update
@@ -5,4 +5,4 @@
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-01 7    * * *   root    /usr/sbin/rule-update
+01 7    * * *   root    /usr/sbin/rule-update > /dev/null


### PR DESCRIPTION
Without stdout redirect, the new wrapper call for rule-update (issue 985,
commit dbe0609) also generates an email from cron every time rule-update
is called, since tee not only appends to the logfile, but sends to stdout.

This patch restores the crontab stdout redirect when rule-update is called from
cron, sending it to /dev/null.  Running from the CLI still outputs to both the
logfile and stdout.

Note that emails are only generated from cron if a mailer daemon
such as exim4-daemon-light is installed, so this issue is not visible to
most users with a stock SecurityOnion installation.

Test procedure:
1. install SecurityOnion (or restore clean snapshot)
2. install exim4-daemon-light
3. wait for cron to run rule-update
4. examine /var/log/nsm/pulledpork.log (should see rule-update output)
5. examine default user's mail file (should see rule-update output)
6. install this update
7. wait for cron to run rule-update
8. examine /var/log/nsm/pulledpork.log (should see new rule-update output)
9. examine default user's mail file (should NOT see new rule-update output)
