### PR TITLE
Add white_list.rules and black_list.rules to worker sync

### DIFF
--- a/usr/bin/rule-update
+++ b/usr/bin/rule-update
@@ -340,6 +340,8 @@ else
 		echo "Copying rules from $SERVERNAME."
 		scp -i "$KEY" $SSH_USERNAME@$SERVERNAME:$NIDS/downloaded.rules 	$NIDS/downloaded.rules
 		scp -i "$KEY" $SSH_USERNAME@$SERVERNAME:$NIDS/local.rules 	$NIDS/local.rules
+                scp -i "$KEY" $SSH_USERNAME@$SERVERNAME:$NIDS/black_list.rules  $NIDS/black_list.rules
+                scp -i "$KEY" $SSH_USERNAME@$SERVERNAME:$NIDS/white_list.rules  $NIDS/white_list.rules
 		scp -i "$KEY" $SSH_USERNAME@$SERVERNAME:$NIDS/sid-msg.map 	$NIDS/sid-msg.map
 		scp -i "$KEY" $SSH_USERNAME@$SERVERNAME:$NIDS/threshold.conf 	$NIDS/threshold.conf
 		scp -i "$KEY" $SSH_USERNAME@$SERVERNAME:$NIDS/bpf.conf 		$NIDS/bpf.conf


### PR DESCRIPTION
With pulledpork.conf having black_list=/etc/nsm/rules/black_list.rules:

Maybe I was doing something wrong with my worker architecture sync but doing rule-udpate on the master and worker didn't pull the white_list.rules and black_list.rules over from /etc/nsm/rules until I added these lines to the worker's sync.

Once added and run on the worker, it pulled the lists from the master and properly alerted.